### PR TITLE
change visibility to public to allow brute force

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,6 +12,6 @@ ports:
   - name: juice-shop
     description: The web app juice-shop
     port: 3000
-    visibility: private
+    visibility: public
     onOpen: open-preview
 


### PR DESCRIPTION
Change the visibility to it's possible to solve a few challenges while Juice Shop is hosted in GitPod